### PR TITLE
Automatically add new hosts to known ssh hosts

### DIFF
--- a/remotekernel/manager.py
+++ b/remotekernel/manager.py
@@ -69,7 +69,8 @@ class RemoteIOLoopKernelManager(KernelManager):
         kernel_cmd = self.format_kernel_cmd(extra_arguments=extra_arguments)
 
         # decide where to copy the connection file on the remote host
-        try_ssh = Popen(['ssh', self.ip, 'exit'], stdin=PIPE, stdout=PIPE)
+        try_ssh = Popen(['ssh',  '-o', 'StrictHostKeyChecking no', self.ip, 'exit'],
+                        stdin=PIPE, stdout=PIPE)
         stdout, stderr = try_ssh.communicate()
         if try_ssh.returncode != 0:
             raise RuntimeError("Failed to connect to remote host {0}. "


### PR DESCRIPTION
I think this may fix at least some of our JupyterHub woes.

REIP has changed all IPs and in a few cases some hosts or network cards have been replaced entirely. This is causing remotekernel to fail to connect, because `ssh` wants you to type "yes" to continue.

Adding this option forces ssh to accept and proceed automatically.